### PR TITLE
Upgrade GitHub Actions to latest versions for artifact upload and deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,9 @@ jobs:
           yarn build:example
           yarn docs
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
           path: "./dist/examples"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Update GitHub Actions to use the latest versions for uploading artifacts and deploying to GitHub Pages.