### PR TITLE
Fix versioning command in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           corepack enable
           yarn set version stable
           yarn install
-          yarn version
+          yarn run version
           yarn build
           yarn build:example
           yarn docs


### PR DESCRIPTION
Update the command in the release workflow to use 'yarn run version' for proper versioning.